### PR TITLE
Added a note that about IOPS/GB.

### DIFF
--- a/doc_source/performance.md
+++ b/doc_source/performance.md
@@ -20,6 +20,8 @@ A file system can always achieve at least its baseline throughput\. File systems
 **Note**  
 These details apply to almost all file system configurations\. However, if configuring high levels of throughput capacity \(file server capacity\) with small amounts of storage, keep in mind that the storage volumes for a file system have a maximum throughput of 750 KBps per GB; for small file systems with high levels of throughput, the storage volume throughput may impact the maximum throughput level your file system can achieve\.
 
+Also note that for SSD based storage, FSx supports 3 IOPS per GB of storage.
+
 ## Higher Throughput with Caching<a name="fsx-higher-throughput"></a>
 
 Amazon FSx also provides in\-memory caching on the Windows file server\. Depending on your workload's access patterns, you may observe even higher levels of throughput \(between 600 MBps and 3 GBps\) by benefiting from this server\-side caching\.


### PR DESCRIPTION
When evaluating performance, it's important to understand that the SSD based storage supports 3 IOPS per GB.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
