### PR TITLE
Fixed a typo in drive mapping name

### DIFF
--- a/doc_source/getting-started-step2.md
+++ b/doc_source/getting-started-step2.md
@@ -28,6 +28,6 @@ You can now mount your Amazon FSx file system to your Microsoft Windows–based 
      amznfsxaa11bb22.ad-domain.com
      ```
 
-   For example, enter `\\fs-0123456789abcdef0\.ad-domain.com\share`\.
+   For example, enter `\\fs-0123456789abcdef0.ad-domain.com\share`\.
 
 1. Choose whether the file share should **Reconnect at sign\-in** and then choose **Finish**\.


### PR DESCRIPTION
Seems like it's a typo, fixed with the correct name.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
